### PR TITLE
Limit Number of Recent Articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ googleAnalytics = "UA-XXXXXXXX-XX" # Optional
 """
 ```
 
+# `config.toml` optional theme params
+
+```
+[params]
+  recents = 5 # Optional. Five is the default value that will be used if this is not set 
+```
+
+**recents** 
+
+Limits the number of recent articles to show at the end of a single post. Defaults to 5.
+
 # Frontmatter example
 
 ```

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,7 +14,8 @@
   <section>
     <header>Recent articles</header>
     <ul class="p-articles bordered">
-      {{ range $recent_articles }}<li>{{ .Render "li_sm" }}</li>{{ end }}
+      {{ $recent_limit := .Site.Params.Recents | default 5 }}
+      {{ range first $recent_limit $recent_articles }}<li>{{ .Render "li_sm" }}</li>{{ end }}
     </ul>
   </section>
   {{ end }}


### PR DESCRIPTION
Provides an optional parameter `recents` to limit the number of recent articles shown when viewing a single post. I set the default value to 5 because that looked good to me on my blog, but maybe it should be higher?