### PR TITLE
Comments Partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ Recommend that you use the section than taxonomy.
         └── thumbnail.png
 ```
 
+# Partials
+
+## comments.html
+
+Use this partial to configure an amp compatible commenting system like Disqus. This partial
+is rendered on single posts after the post summary but before the list of recent posts. By 
+default this partial is empty. 
+
 # Shortcodes
 
 ## Iframe

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,6 +8,7 @@
 {{ define "main" }}
 <div class="l-container">
   {{ .Render "summary" }}
+  {{ partial "comments.html" . }}
 
   {{ $recent_articles := (where .Site.Pages ".Source.Path" "!=" .Source.Path) }}
   {{ if ne 0 (len $recent_articles) }}


### PR DESCRIPTION
Adds a comments partial that can be used to integrate disqus or similar AMP friendly comment systems at the end of each post. I use this for disqus but by providing an empty partial people can either use it or not easily.

I populate the partial with this for disqus:

```
<amp-iframe width=600 height=140
            layout="responsive"
            sandbox="allow-scripts allow-same-origin allow-modals allow-popups allow-forms"
            resizable
            src="https://someurl.biz/js/amp-disqus-uc.html#{{ .Title }}">
    <div overflow tabindex=0 role=button aria-label="Read more">More Comments...</div>
</amp-iframe>
```

see also https://github.com/disqus/disqus-install-examples/tree/master/google-amp

