### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ googleAnalytics = "UA-XXXXXXXX-XX" # Optional
   googlefonts = "https://fonts.googleapis.com/css?family=Lobster|Lato:400,700" # Optional, Include google fonts.
   fontfamily = "Lato,YuGothic,'Hiragino Kaku Gothic Pro',Meiryo,sans-serif" # Optional, Override body font family.
   logofontfamily = "Lobster, cursive" # Optional, Override logo font.
-  ampscripts = """ # Optional, scripts for AMP.
+   # Optional, scripts for AMP.
+  ampscripts = """
 <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
 <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
 <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>


### PR DESCRIPTION
Hash (\#) is not recognized by HTML as comment. The current commented segment ends up directly being a part of rendered HTML, which ends up generating error in AMP validation. 
Therefore, it is now extracted from the ampscripts value.